### PR TITLE
Handling of severity > 3 updated

### DIFF
--- a/carchive/backend/pb/exporter.py
+++ b/carchive/backend/pb/exporter.py
@@ -156,7 +156,8 @@ class Exporter(object):
             #samples with severity 3904, 3848 and 3872 are not stored: the info they provide is used
             #with the next healthy value
             return
-        elif sevr == 3856 or sevr == 3968:
+        elif sevr > 3:
+            #sevr == 3856 or sevr == 3968:
             #if the severity is Repeat or Est_Repeat, log a warning
             self._pvlog.warning("Severity {0} encountered!".format(sevr))
         else:

--- a/carchive/backend/pb/exporter.py
+++ b/carchive/backend/pb/exporter.py
@@ -159,7 +159,7 @@ class Exporter(object):
         elif sevr > 3:
             #sevr == 3856 or sevr == 3968:
             #if the severity is Repeat or Est_Repeat, log a warning
-            self._pvlog.warning("Severity {0} encountered!".format(sevr))
+            self._pvlog.warning("Severity {0} encountered at {1}!".format(sevr,secnano))
         else:
             if self._pv_disconnected is True:
                 sample_pb.fieldvalues.extend([pbt.FieldValue(name='cnxlostepsecs', val='{0}'.format(self._previous_dt_seconds))])


### PR DESCRIPTION
Updated handling of samples with severity > 3.
3904 (disconnected) - add cnxlostepsecs and cnxregainedepsecs
3872 (archive off) - add startup=true
3848 (archive disabled) - add resume=true (not needed by the appliance)
3856, 3968 (Repeat and Est_Repeat) - write unchanged and log a warning
