### PR TITLE
error on no --pv-list file

### DIFF
--- a/arget
+++ b/arget
@@ -107,7 +107,11 @@ if opt.pvlist:
     if opt.pvlist == '-':
         AF = sys.stdin
     else:
-        AF = open(opt.pvlist, 'r')
+        try:
+            AF = open(opt.pvlist, 'r')
+        except IOError:
+            print "--pv-list: No such file or directory: '%s'"%opt.pvlist
+            sys.exit(0)
     args += filter(lambda L:len(L) and L[0]!='#', map(str.rstrip, AF.readlines()))
     if opt.pvlist != '-':
         AF.close()


### PR DESCRIPTION
Small fix to prevent the following:

$ arget --pv-list whatever
Traceback (most recent call last):
  File "/usr/bin/arget", line 104, in <module>
    AF = open(opt.pvlist, 'r')
IOError: [Errno 2] No such file or directory: 'whatever'