### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 carchivetools
 =============
 
+**Notice** The package is considered to be deprecated in favor of
+[aaclient](https://github.com/mdavidsaver/aaclient).
+
 <a href="https://travis-ci.org/epicsdeb/carchivetools">
   <img src="https://travis-ci.org/epicsdeb/carchivetools.svg" title="Build Status Images">
 </a>

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,12 @@ from distutils.command import build, build_ext, install
 
 from numpy.distutils.misc_util import get_numpy_include_dirs
 
+import warnings
+
 if sys.version_info<(3,7):
-    import warnings
     warnings.warn("Python < 3.7 is no longer supported")
+
+warnings.warn("Deprecated in favor of https://github.com/mdavidsaver/aaclient")
 
 class GenProtobuf(Command):
     """Run protoc code generator


### PR DESCRIPTION
On consideration, merging #10 seems like a more or less reasonable place to stop working on this package (after ~11 years).  I have not done much with the twisted matrix libraries in years.  It has been even longer since I did anything with Channel Archiver.

Over the holidays I started [aaclient](https://github.com/mdavidsaver/aaclient) which is a rewrite of the Archiver Appliance client functionality only.  The basic structure is the same, with the major change being asyncio with async/await, which requires python >=3.7.  There are also a number of more subtle changes (eg. dates always year/month/day).  imo. this is different enough to justify new names (eg. `arget` becomes `aaget`).  So it will not conflict with concurrent use of carchivetools.